### PR TITLE
Bugfix for ESC8 Check

### DIFF
--- a/Private/Set-AdditionalCAProperty.ps1
+++ b/Private/Set-AdditionalCAProperty.ps1
@@ -36,7 +36,6 @@
     )
 
     begin {
-        $CAEnrollmentEndpoint = @()
         if (-not ([System.Management.Automation.PSTypeName]'TrustAllCertsPolicy') ) {
             if ($PSVersionTable.PSEdition -eq 'Desktop') {
                 $code = @"
@@ -69,6 +68,7 @@
 
     process {
         $ADCSObjects | Where-Object objectClass -Match 'pKIEnrollmentService' | ForEach-Object {
+            $CAEnrollmentEndpoint = @()
             #[array]$CAEnrollmentEndpoint = $_.'msPKI-Enrollment-Servers' | Select-String 'http.*' | ForEach-Object { $_.Matches[0].Value }
             foreach ($directory in @("certsrv/", "$($_.Name)_CES_Kerberos/service.svc", "$($_.Name)_CES_Kerberos/service.svc/CES", "ADPolicyProvider_CEP_Kerberos/service.svc", "certsrv/mscep/")) {
                 $URL = "://$($_.dNSHostName)/$directory"


### PR DESCRIPTION
Expected Behavior:
In environments with multiple web enrollment endpoints, the ESC8 vulnerability is only shown for the specific endpoint it was identified on.

Observed Behavior:
In environments with multiple CAs with web enrollment endpoints, if one CA has a vulnerable endpoint and the others do not, ESC8 shows up for all of the endpoints checked after it in the Foreach-Object loop.

Reproducing:
Setup two CAs, one with a vulnerable CA and one with a non-vulnerable CA. The Non-vulnerable CA should be alphabetically after the vulnerable CA so that it ends up after the vulnerable CA in the looping of $ADCSObject

Cause:
Currently, the $CAEnrollmentEndpoint array is in the begin{} block in the Set-AdditionalCAProperty function. Objecs in the begin{} block are scoped for the entire function.

Moving the instantiation to the Foreach-Object loop where the Enrollment Endpoints in $ADCSObject are being iterated solves the issue. This creates a new, empty array for each CA rather than re-using the previous array. I believe this is the desired behavior.