### PR TITLE
Domain Admins w/ Ownership of CA Host Object Is Not a Risk!

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -1164,7 +1164,15 @@ function Find-ESC5 {
         }
 
         $IssueDetail = ''
-        if ( ($_.objectClass -ne 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {
+        $DangerousOwner = $false
+        if ( ($_.objectClass -eq 'computer') -and ($SID -match '-512$') ) {
+            $DangerousOwner = $false
+        }
+        elseif ( ($_.objectClass -ne 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {
+            $DangerousOwner = $true
+        }
+
+        if ($DangerousOwner) {
             switch ($_.objectClass) {
                 container {
                     $IssueDetail = @"
@@ -1177,7 +1185,8 @@ CA objects, new templates, new OIDs, etc. to create novel escalation paths.
                     $IssueDetail = @"
 This computer is hosting a Certification Authority (CA).
 
-There is no reason for anyone other than AD Admins to have own CA host objects.
+There is no reason for anyone other than Enterprise Admins or Domain Admins to
+own CA host objects.
 "@
                 }
                 'msPKI-Cert-Template-OID' {
@@ -1197,7 +1206,7 @@ Ownership rights can be used to enable currently disabled templates.
 
 If this prinicpal also has control over a disabled certificate template (aka ESC4),
 they could modify the template into an ESC1 template and enable the certificate.
-This ensabled certificate could be use for privilege escalation and persistence.
+This enabled certificate could be use for privilege escalation and persistence.
 "@
                 }
             }
@@ -4381,7 +4390,7 @@ function Invoke-Locksmith {
         [System.Management.Automation.PSCredential]$Credential
     )
 
-    $Version = '2025.1.14'
+    $Version = '2025.2.22'
     $LogoPart1 = @'
     _       _____  _______ _     _ _______ _______ _____ _______ _     _
     |      |     | |       |____/  |______ |  |  |   |      |    |_____|

--- a/Locksmith.psd1
+++ b/Locksmith.psd1
@@ -8,7 +8,7 @@
     FunctionsToExport    = 'Invoke-Locksmith'
     GUID                 = 'b1325b42-8dc4-4f17-aa1f-dcb5984ca14a'
     HelpInfoURI          = 'https://raw.githubusercontent.com/jakehildreth/Locksmith/main/en-US/'
-    ModuleVersion        = '2025.1.14'
+    ModuleVersion        = '2025.2.22'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Private/Find-ESC5.ps1
+++ b/Private/Find-ESC5.ps1
@@ -87,7 +87,14 @@
         }
 
         $IssueDetail = ''
-        if ( ($_.objectClass -ne 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {
+        $DangerousOwner = $false
+        if ( ($_.objectClass -eq 'computer') -and ($SID -match '-512$') ) {
+            $DangerousOwner = $false
+        } elseif ( ($_.objectClass -ne 'pKICertificateTemplate') -and ($SID -notmatch $SafeOwners) ) {
+            $DangerousOwner = $true
+        }
+
+        if ($DangerousOwner) {
             switch ($_.objectClass) {
                 container {
                     $IssueDetail = @"
@@ -100,7 +107,8 @@ CA objects, new templates, new OIDs, etc. to create novel escalation paths.
                     $IssueDetail = @"
 This computer is hosting a Certification Authority (CA).
 
-There is no reason for anyone other than AD Admins to have own CA host objects.
+There is no reason for anyone other than Enterprise Admins or Domain Admins to
+own CA host objects.
 "@
                 }
                 'msPKI-Cert-Template-OID' {
@@ -120,7 +128,7 @@ Ownership rights can be used to enable currently disabled templates.
 
 If this prinicpal also has control over a disabled certificate template (aka ESC4),
 they could modify the template into an ESC1 template and enable the certificate.
-This ensabled certificate could be use for privilege escalation and persistence.
+This enabled certificate could be use for privilege escalation and persistence.
 "@
                 }
             }


### PR DESCRIPTION
This PR resolves Issues #225 & #230 by adding another conditional statement to ownership checks when the `objectClass` is `computer`. Domain Admins having ownership of CA Host objects is *fine*.