### PR TITLE
Minor update and fix pre-merge script block

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -32,7 +32,7 @@ Build-Module -ModuleName 'Locksmith' {
         ProjectUri           = 'https://github.com/jakehildreth/Locksmith'
         IconUri              = 'https://raw.githubusercontent.com/jakehildreth/Locksmith/main/Images/locksmith.ico'
         PowerShellVersion    = '5.1'
-        Tags                 = @('Windows', 'Locksmith', 'CA', 'PKI', 'ActiveDirectory', 'CertificateServices', 'ADCS')
+        Tags                 = @('Locksmith', 'ActiveDirectory', 'ADCS', 'CA', 'Certificate', 'CertificateAuthority', 'CertificateServices', 'PKI', 'X509', 'Windows')
     }
     New-ConfigurationManifest @Manifest
 

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -120,9 +120,14 @@ Build-Module -ModuleName 'Locksmith' {
     New-ConfigurationBuild -Enable:$true -SignModule:$false -DeleteTargetModuleBeforeBuild -MergeModuleOnBuild #-UseWildcardForFunctions
 
     $PreScriptMerge = {
-        [CmdletBinding()]
+        [CmdletBinding(HelpUri = 'https://jakehildreth.github.io/Locksmith/Invoke-Locksmith')]
         param (
-            [int]$Mode,
+            # The mode to run Locksmith in. Defaults to 0.
+            [Parameter(Mandatory = $false)]
+            [ValidateSet(0, 1, 2, 3, 4)]
+            [int]$Mode = 0,
+
+            # The scans to run. Defaults to 'All'.
             [Parameter()]
             [ValidateSet('Auditing', 'ESC1', 'ESC2', 'ESC3', 'ESC4', 'ESC5', 'ESC6', 'ESC8', 'ESC11', 'ESC13', 'ESC15', 'EKUwu', 'All', 'PromptMe')]
             [array]$Scans = 'All'

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -120,10 +120,11 @@ Build-Module -ModuleName 'Locksmith' {
     New-ConfigurationBuild -Enable:$true -SignModule:$false -DeleteTargetModuleBeforeBuild -MergeModuleOnBuild #-UseWildcardForFunctions
 
     $PreScriptMerge = {
+        [CmdletBinding()]
         param (
             [int]$Mode,
             [Parameter()]
-            [ValidateSet('Auditing','ESC1','ESC2','ESC3','ESC4','ESC5','ESC6','ESC8','ESC11','ESC13','ESC15','EKUwu','All','PromptMe')]
+            [ValidateSet('Auditing', 'ESC1', 'ESC2', 'ESC3', 'ESC4', 'ESC5', 'ESC6', 'ESC8', 'ESC11', 'ESC13', 'ESC15', 'EKUwu', 'All', 'PromptMe')]
             [array]$Scans = 'All'
         )
     }

--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -1,6 +1,6 @@
 # https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/docs/requirements.txt
 # requirements.txt
-jinja2==3.1.4  #https://pypi.org/project/Jinja2/
+jinja2==3.1.5  #https://pypi.org/project/Jinja2/
 mkdocs>=1.6.0  #https://github.com/mkdocs/mkdocs
 mkdocs-material==9.5.25  #https://github.com/squidfunk/mkdocs-material
 pygments>=2.18.0  #https://pypi.org/project/Pygments/


### PR DESCRIPTION
Updated the pre-merge script block to include the cmdletbinding attribute and full parameter definitions that are already present in Invoke-Locksmith.

Added PSGallery tags to the module manifest after seeing additional tags used by other ADCS/PKI related projects.

Updated the version of Jinja used by MkDocs to the latest version that closes a security vulnerability.

---

Updates to the `Locksmith` module build script:

* [`Build/Build-Module.ps1`](diffhunk://#diff-18f2277968f53700a2a662b37a163487eb01d36a82ae5a49ff6b542816fb6b36L35-R35): Updated the `Tags` property to include additional relevant keywords.
* [`Build/Build-Module.ps1`](diffhunk://#diff-18f2277968f53700a2a662b37a163487eb01d36a82ae5a49ff6b542816fb6b36R123-R130): Added `CmdletBinding` attribute and additional parameters with default values to the `$PreScriptMerge` script block, including a `HelpUri` and descriptions for `Mode` and `Scans` parameters.

Dependency version update:

* [`Docs/requirements.txt`](diffhunk://#diff-1f2ed9c44b518eb49985944f92a7c7bfd80fcb63574acd7e23290130f4d14cbbL3-R3): Updated `jinja2` dependency from version `3.1.4` to `3.1.5`.