### PR TITLE
Update Deploy MkDocs.yml

### DIFF
--- a/.github/workflows/Deploy MkDocs.yml
+++ b/.github/workflows/Deploy MkDocs.yml
@@ -7,11 +7,9 @@ on:
   pull_request:
     branches:
       - main
-      - testing
   push:
     branches:
-      #- main  # The branch you want to deploy from
-      - testing
+      - main  # The branch you want to deploy from
     paths:  # Only deploy MkDocs when the contents of the docs folder change or when this workflow changes
       - 'Docs/**'
       - '.github/workflows/Deploy MkDocs.yml'
@@ -40,29 +38,3 @@ jobs:
         run: |
           mkdocs build
           mkdocs gh-deploy --force
-
-      # Combine markdown files to create the MkDocs index and the repository readme file.
-      - name: 📖 Update Index & Readme
-        shell: pwsh
-        run: |
-          Write-Output 'Updating Docs\Index.md & \Readme.md'
-      # Temporarily disabled until this can be wrapped in a PR that is submitted and merged by the workflow.    
-      #    Copy-Item README.md Docs/index.md
-
-      #    [int16]$LineNumber = (Select-String -Path '.\docs\index.md' -Pattern 'Summary' -List).LineNumber + 1
-      #    $IndexTop = Get-Content -Path ./docs/index.md -TotalCount $LineNumber
-      #    $ModuleContent = Get-Content -Path ./docs/Locksmith.md | Select-Object -Skip 12
-      #    $FooterContent = "`n</Details>`n"
-      #    $CombinedContent = $IndexTop + $ModuleContent + $FooterContent
-      #    $CombinedContent | Set-Content -Path ./docs/index.md
-      #    $ModuleContent = $ModuleContent.Replace( '](' , '](./docs/' )
-      #    $CombinedContent = $IndexTop + $ModuleContent
-      #    $CombinedContent | Set-Content -Path ./README.md
-      #    Copy-Item ./docs/index.md ./README.md
-
-      # NOTE: git-auto-commit-action only runs on Linux-based platforms.
-      - name: 💾 Commit Changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: 'Copy MkDocs README to index'
-          file_pattern: 'README.md Docs/index.md'


### PR DESCRIPTION
Change to only deploy MkDocs when merging a PR to main or pushing to main, as test updates should not update public docs.

Removed unnecessary jobs that were already commented out and unnecessary commit action. Should resolve the workflow failures!