### PR TITLE
Enhance error handling in Get-CAHostObject and Find-ESC7  scripts

### DIFF
--- a/Private/Find-ESC7.ps1
+++ b/Private/Find-ESC7.ps1
@@ -35,7 +35,7 @@
     )
     process {
         $ADCSObjects | Where-Object {
-            ($_.objectClass -eq 'pKIEnrollmentService') -and
+            ($_.objectClass -eq 'pKIEnrollmentService') -and $_.CAHostDistinguishedName -and
             ( ($_.CAAdministrator) -or ($_.CertificateManager) )
         } | ForEach-Object {
             $UnsafeCAAdministrators = Write-Output $_.CAAdministrator -PipelineVariable admin | ForEach-Object {
@@ -64,8 +64,7 @@
                 }
                 if ($UnsafeCAAdministrators) {
                     $Issue.Issue = $Issue.Issue + @"
-Unexpected principals are granted "CA Administrator" rights on this Certification Authority.
-Unsafe CA Administrators: $($UnsafeCAAdministrators -join ', ').
+Unexpected prinicipals ($($UnsafeCAAdministrators -join ', ')) are granted "CA Administrator" rights on this Certification Authority.
 
 "@
                     $Issue.Fix = $Issue.Fix + @"
@@ -79,16 +78,15 @@ Reinstate CA Administrator rights for $($UnsafeCAAdministrators -join ', ')
                 }
                 if ($UnsafeCertificateManagers) {
                     $Issue.Issue = $Issue.Issue + @"
-Unexpected principals are granted "Certificate Manager" rights on this Certification Authority.
-Unexpected Principals: $($UnsafeCertificateManagers -join ', ')
+Unexpected prinicipals ($($UnsafeCertificateManagers -join ', ')) are granted "Certificate Manager" rights on this Certification Authority.
 
 "@
                     $Issue.Fix = $Issue.Fix + @"
-Revoke Certificate Manager rights from $($UnsafeCertificateManagers -join ', ')
+Revoke CA Administrator rights from $($UnsafeCertificateManagers -join ', ')
 
 "@
                     $Issue.Revert = $Issue.Revert + @"
-Reinstate Certificate Manager rights for $($UnsafeCertificateManagers -join ', ')
+Reinstate CA Administrator rights for $($UnsafeCertificateManagers -join ', ')
 
 "@
                 }

--- a/Private/Get-CAHostObject.ps1
+++ b/Private/Get-CAHostObject.ps1
@@ -40,11 +40,11 @@
     process {
         if ($Credential) {
             $ADCSObjects | Where-Object objectClass -Match 'pKIEnrollmentService' | ForEach-Object {
-                Get-ADObject $_.CAHostDistinguishedName -Properties * -Server $ForestGC -Credential $Credential
+                if ($_.CAHostDistinguishedName) { Get-ADObject $_.CAHostDistinguishedName -Properties * -Server $ForestGC -Credential $Credential } else { Write-Warning "Get-CAHostObject: Unable to get information from $($_.DisplayName)" }
             }
         } else {
             $ADCSObjects | Where-Object objectClass -Match 'pKIEnrollmentService' | ForEach-Object {
-                Get-ADObject $_.CAHostDistinguishedName -Properties * -Server $ForestGC
+                if ($_.CAHostDistinguishedName) { Get-ADObject -Identity $_.CAHostDistinguishedName -Properties * -Server $ForestGC } else { Write-Warning "Get-CAHostObject: Unable to get information from $($_.DisplayName)" }
             }
         }
     }


### PR DESCRIPTION
- Improved error handling in the Get-CAHostObject and Find-ESC7 scripts by verifying the presence of CAHostDistinguishedName before retrieving AD objects.

I did not modify the Invoke-Locksmith.ps1 file because my editor automatically changes the spacing between 'if' and 'else'. I'm unsure if this is a bug or if the file does not adhere to the specified formatting option.

“powershell.codeFormatting.preset": ‘OTBS’.

**Before fix:**
```powershell
PS C:\Users\blabla\Documents\WindowsPowerShell\Modules\Locksmith> Invoke-Locksmith -Scans ESC7 -Verbose
    _       _____  _______ _     _ _______ _______ _____ _______ _     _
    |      |     | |       |____/  |______ |  |  |   |      |    |_____|
    |_____ |_____| |_____  |    \_ ______| |  |  | __|__    |    |     |
        .--.                  .--.                  .--.
       /.-. '----------.     /.-. '----------.     /.-. '----------.
       \'-' .---'-''-'-'     \'-' .--'--''-'-'     \'-' .--'--'-''-'
        '--'                  '--'                  '--'
                                                          v<ModuleVersion>
Gathering AD CS Objects from pharmax.local...
WARNING: Unable to resolve pharmax-CAYEY-DC-01V-CA Fully Qualified Domain Name (FQDN)
Get-ADObject : Cannot validate argument on parameter 'Identity'. The argument is null. Provide a valid value for the argument, and then try running the command again.
At C:\Users\blabla\Documents\WindowsPowerShell\Modules\Locksmith\Private\Get-CAHostObject.ps1:47 char:30
+                 Get-ADObject $_.CAHostDistinguishedName -Properties * ...
+                              ~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Get-ADObject], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationError,Microsoft.ActiveDirectory.Management.Commands.GetADObject
 
Identifying Issuing CAs with ESC7...
Exception calling "Translate" with "1" argument(s): "The trust relationship between the primary domain and the trusted domain failed.
"
At C:\Users\blabla\Documents\WindowsPowerShell\Modules\Locksmith\Private\Convert-IdentityReferenceToSid.ps1:33 char:9
+         $SID = ($Principal.Translate([System.Security.Principal.Secur ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : SystemException
 
Exception calling "Translate" with "1" argument(s): "The trust relationship between the primary domain and the trusted domain failed.
"
At C:\Users\blabla\Documents\WindowsPowerShell\Modules\Locksmith\Private\Convert-IdentityReferenceToSid.ps1:33 char:9
+         $SID = ($Principal.Translate([System.Security.Principal.Secur ...
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : SystemException

05/19/2025 14:54:52 : No ADCS issues were found.
PS C:\Users\blabla\Documents\WindowsPowerShell\Modules\Locksmith> 
```

**After fix:**
```powershell
PS C:\Users\blabla\Documents\WindowsPowerShell\Modules\Locksmith> Invoke-Locksmith -Scans ESC7 -Verbose
    _       _____  _______ _     _ _______ _______ _____ _______ _     _
    |      |     | |       |____/  |______ |  |  |   |      |    |_____|
    |_____ |_____| |_____  |    \_ ______| |  |  | __|__    |    |     |
        .--.                  .--.                  .--.
       /.-. '----------.     /.-. '----------.     /.-. '----------.
       \'-' .---'-''-'-'     \'-' .--'--''-'-'     \'-' .--'--'-''-'
        '--'                  '--'                  '--'
                                                          v<ModuleVersion>
Gathering AD CS Objects from pharmax.local...
WARNING: Unable to resolve pharmax-CAYEY-DC-01V-CA Fully Qualified Domain Name (FQDN)
WARNING: Get-CAHostObject: Unable to get information from pharmax-CAYEY-DC-01V-CA
Identifying Issuing CAs with ESC7...
----------------------------------------
     ESC7 - Non-standard PKI Admins     
----------------------------------------

Technique CA Name                  Risk   Issue
--------- -------                  ----   -----
ESC7      pharmax-SERVER-DC-01V-CA Medium Unexpected prinicipals (NT AUTHORITY\Authenticated Users) are granted "CA Administrator" rights on this Certification Authority.
                                          Unexpected prinicipals (NT AUTHORITY\Authenticated Users) are granted "Certificate Manager" rights on this Certification Authority.

                                          More info:
                                            - https://posts.specterops.io/certified-pre-owned-d95910965cd2



[!] You ran Locksmith in Mode 0 which only provides an high-level overview of issues
identified in the environment. For more details including:

  - DistinguishedName of impacted object(s)
  - Remediation guidance and/or code
  - Revert guidance and/or code (in case remediation breaks something!)

Run Locksmith in Mode 1!

# Module version
Invoke-Locksmith -Mode 1

# Script version
.\Invoke-Locksmith.ps1 -Mode 1

Thank you for using Locksmith <3

```