### PR TITLE
Add custom mermaid fence support to markdown extensions in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,3 +83,10 @@ theme:
     - navigation.top
     - toc.follow
     - toc.integrate
+
+markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format


### PR DESCRIPTION
Edited mkdocs.yml file to add support for mermaid rendering.

<img width="1744" height="1036" alt="image" src="https://github.com/user-attachments/assets/4ac7c121-a056-4730-a655-eba328ed7bfc" />

<img width="2758" height="1286" alt="image" src="https://github.com/user-attachments/assets/d644ad37-e29d-491b-9c35-07860006ef23" />
