### PR TITLE
Add OpenSSF-facing repository hygiene documents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- Describe the change and why it is needed. -->
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Security hardening
+- [ ] Refactoring
+- [ ] Build, CI, or repository maintenance
+
+## Validation
+
+<!-- Describe the checks you ran. If a check is not applicable, explain why. -->
+
+- [ ] PSScriptAnalyzer
+- [ ] Pester tests
+- [ ] Manual validation
+- [ ] Documentation-only change
+
+## Security impact
+
+<!-- Describe any effect on AD CS discovery, remediation, credentials, generated scripts, network requests, or repository supply chain. -->
+
+## Documentation impact
+
+<!-- Note README, Docs, external help, or support/security policy updates. -->
+
+## PowerShell compatibility
+
+<!-- Note affected versions or platforms, such as Windows PowerShell 5.1, PowerShell 7, Windows Server, or RSAT requirements. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ to <coc@dotdot.horse>.
 
 ## Security
 
-Never report security related issues, vulnerabilities, or bugs including
+Never report security-related issues, vulnerabilities, or bugs including
 sensitive information to the issue tracker or elsewhere in public. Follow the
 [Locksmith Security Policy](SECURITY.md) instead.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,8 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 - [Contributing to Locksmith](#contributing-to-locksmith)
   - [Code of Conduct](#code-of-conduct)
+  - [Security](#security)
+  - [Support](#support)
   - [I Have a Question](#i-have-a-question)
   - [I Want To Contribute](#i-want-to-contribute)
     - [Reporting Bugs](#reporting-bugs)
@@ -28,6 +30,17 @@ This project and everyone participating in it is governed by the
 [Locksmith Code of Conduct](https://github.com/jakehildreth/Locksmith/blob/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <coc@dotdot.horse>.
+
+## Security
+
+Never report security related issues, vulnerabilities, or bugs including
+sensitive information to the issue tracker or elsewhere in public. Follow the
+[Locksmith Security Policy](SECURITY.md) instead.
+
+## Support
+
+For usage questions, troubleshooting, and bug report guidance, see
+[Locksmith Support](SUPPORT.md).
 
 ## I Have a Question
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A small tool built to find and fix common misconfigurations in Active Directory 
    4. [Mode 3](#mode-3-identify-issues-and-fixes-output-to-csv)
    5. [Mode 4](#mode-4-fix-all-issues)
    6. [Scans](#scans)
+3. [Security and Support](#security-and-support)
 
 <a name="installation" id="installation"></a>
 ## Installation
@@ -189,5 +190,10 @@ Invoke-Locksmith.ps1 -Scans ESC1
 # Scan for ESC1, ESC2, and ESC8 vulnerable paths
 Invoke-Locksmith.ps1 -Scans ESC1,ESC2,ESC8
 ```
+
+## Security and Support
+
+For vulnerability reporting, see the [Security Policy](SECURITY.md).
+For usage questions and support guidance, see [Support](SUPPORT.md).
 
 Thank you for using Locksmith! 💜

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are prioritized for the latest published Locksmith release and
+the current `main` branch. If you are using an older release, upgrade to the
+latest release before reporting unless the issue is specific to the upgrade
+path.
+
+## Reporting a vulnerability
+
+Do not report security vulnerabilities in public GitHub issues, discussions, or
+pull requests.
+
+Email vulnerability reports to <security@dotdot.horse>. Include as much of the
+following information as you can safely share:
+
+- The Locksmith version or commit SHA.
+- The affected command, mode, scan, or remediation path.
+- The Windows and PowerShell versions used.
+- A clear description of the security impact.
+- Minimal reproduction steps, sample output, or logs with secrets and sensitive
+  environment details removed.
+- Whether the issue is already being exploited or publicly discussed.
+
+The maintainers will review the report, coordinate follow-up privately, and
+publish public details after a fix or mitigation is available when disclosure is
+appropriate.
+
+## Handling sensitive AD CS data
+
+Locksmith output can include names, distinguished names, SIDs, certificate
+authority details, and remediation commands from an Active Directory
+environment. Remove organization-specific or sensitive values before sharing
+logs, screenshots, generated scripts, CSV files, or command output publicly.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,31 @@
+# Support
+
+## Questions and usage help
+
+Start with the project documentation:
+
+- [README](README.md)
+- [Published documentation](https://jakehildreth.github.io/Locksmith/)
+
+If the documentation does not answer your question, search existing
+[GitHub issues](https://github.com/jakehildreth/Locksmith/issues). If there is
+no related issue, open a new issue and include:
+
+- Locksmith version.
+- Windows version.
+- PowerShell version and host.
+- Whether the forest is single-domain or multi-domain.
+- The command you ran, with sensitive values removed.
+- The behavior you expected and what happened instead.
+
+## Bug reports
+
+Use the
+[bug report template](https://github.com/jakehildreth/Locksmith/issues/new/choose)
+for reproducible bugs. Include enough detail for maintainers to reproduce the
+issue without access to your environment.
+
+## Security reports
+
+Do not report vulnerabilities or sensitive environment details in public issues.
+Follow the [security policy](SECURITY.md) instead.


### PR DESCRIPTION
## Summary

Adds repository hygiene documents that make support, security reporting, and contribution review expectations easier to find:

- `SECURITY.md` for private vulnerability reporting and sensitive AD CS data handling guidance
- `SUPPORT.md` for usage questions, bug reports, and security report routing
- `.github/PULL_REQUEST_TEMPLATE.md` for validation, security impact, documentation impact, and PowerShell compatibility notes
- README and contributing links to the new guidance

## Notes

An untracked local review note named `BRANCH_PROTECTION_AND_RULESETS_REVIEW.md` was created for owner discussion and intentionally left out of this PR.

## Deferred

- No Pester tests or code coverage changes
- No `Write-Host` cleanup
- No plural noun warning cleanup
- No remediation or TLS behavior changes

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>