### PR TITLE
Add Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+---
+version: 2
+
+updates:
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Keep MkDocs Python dependencies up to date
+  - package-ecosystem: "pip"
+    directory: "/Docs"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "python"


### PR DESCRIPTION
## Summary

Adds .github/dependabot.yml to keep the repository's dependencies automatically up to date.

## Coverage

| Ecosystem | Directory | Schedule | Labels |
|-----------|-----------|----------|--------|
| `github-actions` | `/` | Monthly | `dependencies`, `github-actions` |
| `pip` | `/Docs` | Monthly | `dependencies`, `python` |

## Details

- **GitHub Actions** — monitors all workflow files under `.github/workflows`\ for action version updates (e.g. `actions/checkout`, `actions/setup-python`, `oxsecurity/megalinter`, etc.)
- **Python (pip)** — monitors \Docs/requirements.txt\ which pins MkDocs and related docs-build dependencies (`mkdocs`, `mkdocs-material`, `jinja2`, `pygments`)

Monthly schedule keeps noise low while still catching security patches and compatibility fixes in a timely manner.

## No-change areas

- No Pester tests added or modified
- No unrelated workflow changes