### PR TITLE
Fix template enabled-state assignment

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -3476,10 +3476,9 @@ function Set-AdditionalTemplateProperty {
                     $Enabled = $true
                     $EnabledOn += $ca.Name
                 }
-
-                $template | Add-Member -NotePropertyName Enabled -NotePropertyValue $Enabled -Force
-                $template | Add-Member -NotePropertyName EnabledOn -NotePropertyValue $EnabledOn -Force
             }
+            $template | Add-Member -NotePropertyName Enabled -NotePropertyValue $Enabled -Force
+            $template | Add-Member -NotePropertyName EnabledOn -NotePropertyValue $EnabledOn -Force
         }
     }
 }

--- a/Private/Set-AdditionalTemplateProperty.ps1
+++ b/Private/Set-AdditionalTemplateProperty.ps1
@@ -38,10 +38,9 @@
                     $Enabled = $true
                     $EnabledOn += $ca.Name
                 }
-
-                $template | Add-Member -NotePropertyName Enabled -NotePropertyValue $Enabled -Force
-                $template | Add-Member -NotePropertyName EnabledOn -NotePropertyValue $EnabledOn -Force
             }
+            $template | Add-Member -NotePropertyName Enabled -NotePropertyValue $Enabled -Force
+            $template | Add-Member -NotePropertyName EnabledOn -NotePropertyValue $EnabledOn -Force
         }
     }
 }


### PR DESCRIPTION
## Summary

Move `Add-Member` calls for `Enabled` and `EnabledOn` outside the inner `foreach ($ca ...)` loop in `Set-AdditionalTemplateProperty`, so both properties are computed across **all** enrollment services before being assigned to the template object.

## Problem

In the original code, `Add-Member` was called on **every iteration** of the CA loop — once per enrollment service per template — writing intermediate state to the template object before all CAs had been checked:

```powershell
foreach ($ca in ($ADCSObjects | Where-Object objectClass -EQ 'pKIEnrollmentService')) {
    if ($ca.certificateTemplates -contains $template.Name) {
        $Enabled = $true
        $EnabledOn += $ca.Name
    }

    # BUG: called inside loop — fires on every CA, not just at the end
    $template | Add-Member -NotePropertyName Enabled -NotePropertyValue $Enabled -Force
    $template | Add-Member -NotePropertyName EnabledOn -NotePropertyValue $EnabledOn -Force
}
```

This causes two issues:
1. **Performance**: `Add-Member` is invoked O(n_cas) times per template instead of once.
2. **Correctness**: The template object receives partial/intermediate values during the loop. Any code that reads `Enabled`/`EnabledOn` concurrently (or after an early-exit scenario) could see incorrect state.

## Fix

Move both `Add-Member` calls to after the loop completes:

```powershell
foreach ($ca in ($ADCSObjects | Where-Object objectClass -EQ 'pKIEnrollmentService')) {
    if ($ca.certificateTemplates -contains $template.Name) {
        $Enabled = $true
        $EnabledOn += $ca.Name
    }
}
# Assigned once, after all CAs have been checked
$template | Add-Member -NotePropertyName Enabled -NotePropertyValue $Enabled -Force
$template | Add-Member -NotePropertyName EnabledOn -NotePropertyValue $EnabledOn -Force
```

## Files Changed

- `Private/Set-AdditionalTemplateProperty.ps1` — source fix
- `Invoke-Locksmith.ps1` — generated artifact updated in parity with the build convention (copied from `Artefacts/Script/` by `Build/Build-Module.ps1`)

## Validation

- PSScriptAnalyzer: no warnings or errors on the changed file
- No existing behavior changed — object mutation and output are preserved; only the assignment timing and call count change