### PR TITLE
Fix output path helper parameters

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -3136,8 +3136,8 @@ function New-OutputPath {
         Creates output directories for each forest.
 
     .DESCRIPTION
-        This script creates one output directory per forest specified in the $Targets variable.
-        The output directories are created under the $OutputPath directory.
+        Creates one output directory per forest specified in the Targets parameter.
+        The output directories are created under the OutputPath directory.
 
     .PARAMETER Targets
         Specifies the forests for which output directories need to be created.
@@ -3152,11 +3152,18 @@ function New-OutputPath {
     #>
 
     [CmdletBinding(SupportsShouldProcess)]
-    param ()
-    # Create one output directory per forest
-    foreach ( $forest in $Targets ) {
-        $ForestPath = $OutputPath + "`\" + $forest
-        New-Item -Path $ForestPath -ItemType Directory -Force  | Out-Null
+    param (
+        [Parameter(Mandatory)]
+        [array]$Targets,
+
+        [Parameter(Mandatory)]
+        [string]$OutputPath
+    )
+    foreach ($forest in $Targets) {
+        $ForestPath = Join-Path -Path $OutputPath -ChildPath $forest
+        if ($PSCmdlet.ShouldProcess($ForestPath, 'Create directory')) {
+            New-Item -Path $ForestPath -ItemType Directory -Force | Out-Null
+        }
     }
 }
 

--- a/Private/New-OutputPath.ps1
+++ b/Private/New-OutputPath.ps1
@@ -4,8 +4,8 @@
         Creates output directories for each forest.
 
     .DESCRIPTION
-        This script creates one output directory per forest specified in the $Targets variable.
-        The output directories are created under the $OutputPath directory.
+        Creates one output directory per forest specified in the Targets parameter.
+        The output directories are created under the OutputPath directory.
 
     .PARAMETER Targets
         Specifies the forests for which output directories need to be created.
@@ -20,10 +20,17 @@
     #>
 
     [CmdletBinding(SupportsShouldProcess)]
-    param ()
-    # Create one output directory per forest
-    foreach ( $forest in $Targets ) {
-        $ForestPath = $OutputPath + "`\" + $forest
-        New-Item -Path $ForestPath -ItemType Directory -Force  | Out-Null
+    param (
+        [Parameter(Mandatory)]
+        [array]$Targets,
+
+        [Parameter(Mandatory)]
+        [string]$OutputPath
+    )
+    foreach ($forest in $Targets) {
+        $ForestPath = Join-Path -Path $OutputPath -ChildPath $forest
+        if ($PSCmdlet.ShouldProcess($ForestPath, 'Create directory')) {
+            New-Item -Path $ForestPath -ItemType Directory -Force | Out-Null
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes correctness and style issues in `New-OutputPath`, a private helper function that creates per-forest output directories.

## Changes

### `Private/New-OutputPath.ps1`
- **Add declared parameters**: `$Targets` and `$OutputPath` were missing from the `param()` block; the function previously relied on ambient scope variables, which is fragile and undocumented.
- **Replace string concatenation**: Replaced `$OutputPath + "\" + $forest` with `Join-Path -Path $OutputPath -ChildPath $forest` for cross-platform correctness.
- **Activate ShouldProcess**: `SupportsShouldProcess` was declared in `CmdletBinding` but `$PSCmdlet.ShouldProcess()` was never called; added the guard so `-WhatIf`/`-Confirm` work correctly.

### `Invoke-Locksmith.ps1` (monolithic)
- Mirrors the same fix per repository convention (the monolithic file is committed and manually kept in sync with source, as evidenced by prior commits).

## Notes
- `New-OutputPath` is currently dead code (no call sites exist in the module), but it is loaded by the build pipeline and should be correct.
- No behavioral change for existing callers; parameters are additive.
- PSScriptAnalyzer reports no warnings or errors on the changed file.
- No Pester tests added (out of scope per task definition).
