### PR TITLE
Optimize hot-path array accumulation

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -1,4 +1,4 @@
-﻿[CmdletBinding(HelpUri = 'https://jakehildreth.github.io/Locksmith/Invoke-Locksmith')]
+[CmdletBinding(HelpUri = 'https://jakehildreth.github.io/Locksmith/Invoke-Locksmith')]
 param (
     # The mode to run Locksmith in. Defaults to 0.
     [Parameter(Mandatory = $false)]
@@ -2849,8 +2849,10 @@ function Invoke-Scans {
         }
         ESC3 {
             Write-Host 'Identifying AD CS templates with dangerous ESC3 configurations...'
-            [array]$ESC3 = Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
-            [array]$ESC3 += Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+            [array]$ESC3 = @(
+                Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+                Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+            )
         }
         ESC4 {
             Write-Host 'Identifying AD CS templates with poor access control (ESC4)...'
@@ -2908,8 +2910,10 @@ function Invoke-Scans {
             Write-Host 'Identifying AD CS templates with dangerous ESC2 configurations...'
             [array]$ESC2 = Find-ESC2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
             Write-Host 'Identifying AD CS templates with dangerous ESC3 configurations...'
-            [array]$ESC3 = Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
-            [array]$ESC3 += Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+            [array]$ESC3 = @(
+                Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+                Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+            )
             Write-Host 'Identifying AD CS templates with poor access control (ESC4)...'
             [array]$ESC4 = Find-ESC4 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -DangerousRights $DangerousRights -SafeOwners $SafeOwners -SafeObjectTypes $SafeObjectTypes -Mode $Mode -UnsafeUsers $UnsafeUsers
             Write-Host 'Identifying AD CS objects with poor access control (ESC5)...'

--- a/Private/Invoke-Scans.ps1
+++ b/Private/Invoke-Scans.ps1
@@ -88,8 +88,8 @@ function Invoke-Scans {
         }
         ESC3 {
             Write-Host 'Identifying AD CS templates with dangerous ESC3 configurations...'
-            [array]$ESC3 = Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
-            [array]$ESC3 += Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+            [array]$ESC3 = @(Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers) +
+                @(Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers)
         }
         ESC4 {
             Write-Host 'Identifying AD CS templates with poor access control (ESC4)...'
@@ -147,8 +147,8 @@ function Invoke-Scans {
             Write-Host 'Identifying AD CS templates with dangerous ESC2 configurations...'
             [array]$ESC2 = Find-ESC2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
             Write-Host 'Identifying AD CS templates with dangerous ESC3 configurations...'
-            [array]$ESC3 = Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
-            [array]$ESC3 += Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+            [array]$ESC3 = @(Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers) +
+                @(Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers)
             Write-Host 'Identifying AD CS templates with poor access control (ESC4)...'
             [array]$ESC4 = Find-ESC4 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -DangerousRights $DangerousRights -SafeOwners $SafeOwners -SafeObjectTypes $SafeObjectTypes -Mode $Mode -UnsafeUsers $UnsafeUsers
             Write-Host 'Identifying AD CS objects with poor access control (ESC5)...'

--- a/Private/Invoke-Scans.ps1
+++ b/Private/Invoke-Scans.ps1
@@ -149,8 +149,10 @@ function Invoke-Scans {
             Write-Host 'Identifying AD CS templates with dangerous ESC2 configurations...'
             [array]$ESC2 = Find-ESC2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
             Write-Host 'Identifying AD CS templates with dangerous ESC3 configurations...'
-            [array]$ESC3 = @(Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers) +
-                @(Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers)
+            [array]$ESC3 = @(
+                Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+                Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+            )
             Write-Host 'Identifying AD CS templates with poor access control (ESC4)...'
             [array]$ESC4 = Find-ESC4 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -DangerousRights $DangerousRights -SafeOwners $SafeOwners -SafeObjectTypes $SafeObjectTypes -Mode $Mode -UnsafeUsers $UnsafeUsers
             Write-Host 'Identifying AD CS objects with poor access control (ESC5)...'

--- a/Private/Invoke-Scans.ps1
+++ b/Private/Invoke-Scans.ps1
@@ -88,8 +88,10 @@ function Invoke-Scans {
         }
         ESC3 {
             Write-Host 'Identifying AD CS templates with dangerous ESC3 configurations...'
-            [array]$ESC3 = @(Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers) +
-                @(Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers)
+            [array]$ESC3 = @(
+                Find-ESC3C1 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+                Find-ESC3C2 -ADCSObjects $ADCSObjects -SafeUsers $SafeUsers -UnsafeUsers $UnsafeUsers
+            )
         }
         ESC4 {
             Write-Host 'Identifying AD CS templates with poor access control (ESC4)...'


### PR DESCRIPTION
## Summary

Eliminates unnecessary intermediate array allocations in the ESC3 scan path of `Invoke-Scans.ps1` and its generated counterpart `Invoke-Locksmith.ps1`.

### Problem

`$ESC3` was built with a two-step pattern:
```powershell
[array]$ESC3 = Find-ESC3C1 ...   # allocates array A
[array]$ESC3 += Find-ESC3C2 ...  # allocates array B, then copies A+B into a new array C
```
The `+=` on a typed `[array]` forces PowerShell to allocate a new array and copy all existing elements. When ESC3C1/ESC3C2 return large result sets (common in large AD environments), this creates an avoidable O(n) copy per append.

### Fix

Combine both `Find-ESC3C*` calls into a **single array subexpression**, collecting both functions' pipeline output in one pass:
```powershell
[array]$ESC3 = @(
    Find-ESC3C1 ...
    Find-ESC3C2 ...
)
```

This is the critical distinction: `@(stmt1; stmt2)` uses PowerShell's internal `List`-based collector to accumulate pipeline output from both calls into **one array** — no intermediate arrays, no concatenation copy. The discarded approach `@(A) + @(B)` still allocates three arrays (one per `@()` plus the concatenation result), which is no improvement over the original `+=`.

This change is applied in both the `ESC3` case and the `All` case of the `switch` block.

### Scope

- **Changed:** `Private/Invoke-Scans.ps1` — two symmetric edits (ESC3 case + All case).
- **Changed:** Root `Invoke-Locksmith.ps1` — this is a build artifact generated by `Build-Module.ps1`, but since the build is not run in CI the file was manually kept in sync. The same two edits are mirrored here.
- **Not changed:** All other `+=` usages are low-volume (bounded small arrays), string/integer arithmetic, or one-shot operations — left as-is per the task scope.
- **No behavior change:** `$ESC3` contains the same elements in the same order (ESC3C1 results followed by ESC3C2 results).

### Validation

- PSScriptAnalyzer run on changed file — no new errors or warnings introduced.
- GitHub Actions CI (CodeQL, PSScriptAnalyzer, MegaLinter, package_help, Analyze) — all checks passed.