### PR TITLE
Fix spelling and user-facing messages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-# Powershell files
+# PowerShell files
 [*.{ps1,psd1,psm1}]
 indent_size = 4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ If you then still feel the need to ask a question and need clarification, we rec
 
 - Open an [Issue](https://github.com/jakehildreth/Locksmith/issues/new/choose).
 - Provide as much context as you can about what you're running into.
-- Provide project and platform versions (Windows Version, Powershell Version, Windows Terminal, etc.), depending on what seems relevant.
+- Provide project and platform versions (Windows Version, PowerShell Version, Windows Terminal, etc.), depending on what seems relevant.
 
 We will then take care of the issue as soon as possible.
 
@@ -65,7 +65,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 - Collect information about the bug:
   - OS, platform, and version of client machine. (Locksmith is only supported on Windows 10+/2016+ at this time.)
   - Single or multi-domain forest?
-  - PowerShell version, edition, and shell (Windows Powershell / Windows PowerShell ISE / PowerShell / Windows Terminal)
+  - PowerShell version, edition, and shell (Windows PowerShell / Windows PowerShell ISE / PowerShell / Windows Terminal)
   - Possibly your input and the output
   - Can you reliably reproduce the issue?
 

--- a/Docs/Invoke-Locksmith.md
+++ b/Docs/Invoke-Locksmith.md
@@ -18,7 +18,7 @@ Invoke-Locksmith [[-Mode] <Int32>] [[-Scans] <Array>] [[-OutputPath] <String>] [
 ```
 
 ## DESCRIPTION
-Locksmith uses the Active Directory (AD) Powershell (PS) module to identify 10 misconfigurations
+Locksmith uses the Active Directory (AD) PowerShell (PS) module to identify 10 misconfigurations
 commonly found in Enterprise mode AD CS installations.
 
 ## EXAMPLES
@@ -49,7 +49,7 @@ No attempt is made to fix identified issues.
 
 -Mode 1
 Finds any malconfigurations and displays them in the console.
-Displays example Powershell snippet that can be used to resolve the issue.
+Displays example PowerShell snippet that can be used to resolve the issue.
 No attempt is made to fix identified issues.
 
 -Mode 2

--- a/Docs/index.md
+++ b/Docs/index.md
@@ -64,7 +64,7 @@ Install-Module -Name Locksmith -Scope CurrentUser
 <a name="RunLocksmith" id="RunLocksmith"></a>
 
 ## Run Locksmith
-There are several modes you can chose from when running `Invoke-Locksmith`. You can also use the **Scans** parameter to choose which scans you want to invoke.
+There are several modes you can choose from when running `Invoke-Locksmith`. You can also use the **Scans** parameter to choose which scans you want to invoke.
 
 <a name="Mode0" id="Mode0"></a>
 

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -605,7 +605,7 @@ More info:
 
 <#
     Option 2: Scripted Remediation
-    Step 1: Open an elevated Powershell session as an AD or PKI Admin
+    Step 1: Open an elevated PowerShell session as an AD or PKI Admin
     Step 2: Run Unpublish-SchemaV1Templates.ps1
 #>
 Invoke-WebRequest -Uri https://gist.githubusercontent.com/jakehildreth/13c7d615adc905d317fc4379026ad28e/raw/Unpublish-SchemaV1Templates.ps1 | Invoke-Expression
@@ -2720,7 +2720,7 @@ function Invoke-Remediation {
             Write-Host "$($_.Technique)`n"
             Write-Host 'ACTION TO BE PERFORMED:' -ForegroundColor White
             Write-Host "Locksmith will attempt to enable Manager Approval on the `"$($_.Name)`" template.`n"
-            Write-Host 'CCOMMAND(S) TO BE RUN:'
+            Write-Host 'COMMAND(S) TO BE RUN:'
             Write-Host 'PS> ' -NoNewline
             Write-Host "$($_.Fix)`n" -ForegroundColor Cyan
             Write-Host 'OPERATIONAL IMPACT:' -ForegroundColor White
@@ -4874,7 +4874,7 @@ function Write-HostColorized {
             }
         }
         # Otherwise: $PSCmdlet.ParameterSetName -eq 'PerPatternColor', i.e. a dictionary
-        #            mapping patterns to colors was direclty passed in $PatternColorMap
+        #            mapping patterns to colors was directly passed in $PatternColorMap
 
         try {
 
@@ -5019,7 +5019,7 @@ function Invoke-Locksmith {
     Finds the most common malconfigurations of Active Directory Certificate Services (AD CS).
 
     .DESCRIPTION
-    Locksmith uses the Active Directory (AD) Powershell (PS) module to identify 10 misconfigurations
+    Locksmith uses the Active Directory (AD) PowerShell (PS) module to identify 10 misconfigurations
     commonly found in Enterprise mode AD CS installations.
 
     .COMPONENT
@@ -5037,7 +5037,7 @@ function Invoke-Locksmith {
 
     -Mode 1
     Finds any malconfigurations and displays them in the console.
-    Displays example Powershell snippet that can be used to resolve the issue.
+    Displays example PowerShell snippet that can be used to resolve the issue.
     No attempt is made to fix identified issues.
 
     -Mode 2
@@ -5342,7 +5342,7 @@ function Invoke-Locksmith {
             Format-Result -Issue $ESC16 -Mode 0
             Format-Result -Issue $ESC17 -Mode 0
             Write-Host @"
-[!] You ran Locksmith in Mode 0 which only provides an high-level overview of issues
+[!] You ran Locksmith in Mode 0 which only provides a high-level overview of issues
 identified in the environment. For more details including:
 
   - Detailed Risk Rating
@@ -5385,7 +5385,7 @@ Invoke-Locksmith -Mode 1
                 Write-Host "$Output created successfully!`n"
             }
             catch {
-                Write-Host 'Ope! Something broke.'
+                Write-Host "ERROR: Failed to write '$Output'. $($_.Exception.Message)"
             }
         }
         3 {
@@ -5396,7 +5396,7 @@ Invoke-Locksmith -Mode 1
                 Write-Host "$Output created successfully!`n"
             }
             catch {
-                Write-Host 'Ope! Something broke.'
+                Write-Host "ERROR: Failed to write '$Output'. $($_.Exception.Message)"
             }
         }
         4 {

--- a/Private/Find-ESC15.ps1
+++ b/Private/Find-ESC15.ps1
@@ -84,7 +84,7 @@ More info:
 
 <#
     Option 2: Scripted Remediation
-    Step 1: Open an elevated Powershell session as an AD or PKI Admin
+    Step 1: Open an elevated PowerShell session as an AD or PKI Admin
     Step 2: Run Unpublish-SchemaV1Templates.ps1
 #>
 Invoke-WebRequest -Uri https://gist.githubusercontent.com/jakehildreth/13c7d615adc905d317fc4379026ad28e/raw/Unpublish-SchemaV1Templates.ps1 | Invoke-Expression

--- a/Private/Invoke-Remediation.ps1
+++ b/Private/Invoke-Remediation.ps1
@@ -314,7 +314,7 @@ function Invoke-Remediation {
             Write-Host "$($_.Technique)`n"
             Write-Host 'ACTION TO BE PERFORMED:' -ForegroundColor White
             Write-Host "Locksmith will attempt to enable Manager Approval on the `"$($_.Name)`" template.`n"
-            Write-Host 'CCOMMAND(S) TO BE RUN:'
+            Write-Host 'COMMAND(S) TO BE RUN:'
             Write-Host 'PS> ' -NoNewline
             Write-Host "$($_.Fix)`n" -ForegroundColor Cyan
             Write-Host 'OPERATIONAL IMPACT:' -ForegroundColor White

--- a/Private/Write-HostColorized.ps1
+++ b/Private/Write-HostColorized.ps1
@@ -126,7 +126,7 @@ Function Write-HostColorized {
 
         }
         # Otherwise: $PSCmdlet.ParameterSetName -eq 'PerPatternColor', i.e. a dictionary
-        #            mapping patterns to colors was direclty passed in $PatternColorMap
+        #            mapping patterns to colors was directly passed in $PatternColorMap
 
         try {
 

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -4,7 +4,7 @@ function Invoke-Locksmith {
     Finds the most common malconfigurations of Active Directory Certificate Services (AD CS).
 
     .DESCRIPTION
-    Locksmith uses the Active Directory (AD) Powershell (PS) module to identify 10 misconfigurations
+    Locksmith uses the Active Directory (AD) PowerShell (PS) module to identify 10 misconfigurations
     commonly found in Enterprise mode AD CS installations.
 
     .COMPONENT
@@ -22,7 +22,7 @@ function Invoke-Locksmith {
 
     -Mode 1
     Finds any malconfigurations and displays them in the console.
-    Displays example Powershell snippet that can be used to resolve the issue.
+    Displays example PowerShell snippet that can be used to resolve the issue.
     No attempt is made to fix identified issues.
 
     -Mode 2
@@ -324,7 +324,7 @@ function Invoke-Locksmith {
             Format-Result -Issue $ESC16 -Mode 0
             Format-Result -Issue $ESC17 -Mode 0
             Write-Host @"
-[!] You ran Locksmith in Mode 0 which only provides an high-level overview of issues
+[!] You ran Locksmith in Mode 0 which only provides a high-level overview of issues
 identified in the environment. For more details including:
 
   - Detailed Risk Rating
@@ -366,7 +366,7 @@ Invoke-Locksmith -Mode 1
                 $AllIssues | Select-Object Forest, Technique, Name, Issue, @{l = 'Risk'; e = { $_.RiskName } } | Export-Csv -NoTypeInformation $Output
                 Write-Host "$Output created successfully!`n"
             } catch {
-                Write-Host 'Ope! Something broke.'
+                Write-Host "ERROR: Failed to write '$Output'. $($_.Exception.Message)"
             }
         }
         3 {
@@ -376,7 +376,7 @@ Invoke-Locksmith -Mode 1
                 $AllIssues | Select-Object Forest, Technique, Name, DistinguishedName, Issue, Fix, @{l = 'Risk'; e = { $_.RiskName } }, @{l = 'Risk Score'; e = { $_.RiskValue } }, @{l = 'Risk Score Detail'; e = { $_.RiskScoring -join "`n" } } | Export-Csv -NoTypeInformation $Output
                 Write-Host "$Output created successfully!`n"
             } catch {
-                Write-Host 'Ope! Something broke.'
+                Write-Host "ERROR: Failed to write '$Output'. $($_.Exception.Message)"
             }
         }
         4 {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Install-Module -Name Locksmith -Scope CurrentUser
 <a name="run-locksmith" id="run-locksmith"></a>
 ## Run Locksmith
 
-There are several modes you can chose from when running `Invoke-Locksmith`. You can also use the **Scans** parameter to choose which scans you want to invoke.
+There are several modes you can choose from when running `Invoke-Locksmith`. You can also use the **Scans** parameter to choose which scans you want to invoke.
 
 <a name="mode-0-identify-issues-output-to-console-default" id="mode-0-identify-issues-output-to-console-default"></a>
 ### Mode 0: Identify Issues, Output to Console (Default)

--- a/Tests/Invoke-TSS.ps1
+++ b/Tests/Invoke-TSS.ps1
@@ -1,7 +1,7 @@
 <#
     .SYNOPSIS
     Converts a secure Active Directory Certificate Services (AD CS) environment to
-    an insecure AD CS environment to the purposes of testing.
+    an insecure AD CS environment for the purposes of testing.
 
     .DESCRIPTION
     TSS reconfigures Certificate Authorities and creates

--- a/en-US/Locksmith-help.xml
+++ b/en-US/Locksmith-help.xml
@@ -10,7 +10,7 @@
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Locksmith uses the Active Directory (AD) Powershell (PS) module to identify 10 misconfigurations commonly found in Enterprise mode AD CS installations.</maml:para>
+      <maml:para>Locksmith uses the Active Directory (AD) PowerShell (PS) module to identify 10 misconfigurations commonly found in Enterprise mode AD CS installations.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem>
@@ -20,7 +20,7 @@
           <maml:description>
             <maml:para>Specifies sets of common script execution modes.</maml:para>
             <maml:para>-Mode 0 Finds any malconfigurations and displays them in the console. No attempt is made to fix identified issues.</maml:para>
-            <maml:para>-Mode 1 Finds any malconfigurations and displays them in the console. Displays example Powershell snippet that can be used to resolve the issue. No attempt is made to fix identified issues.</maml:para>
+            <maml:para>-Mode 1 Finds any malconfigurations and displays them in the console. Displays example PowerShell snippet that can be used to resolve the issue. No attempt is made to fix identified issues.</maml:para>
             <maml:para>-Mode 2 Finds any malconfigurations and writes them to a series of CSV files. No attempt is made to fix identified issues.</maml:para>
             <maml:para>-Mode 3 Finds any malconfigurations and writes them to a series of CSV files. Creates code snippets to fix each issue and writes them to an environment-specific custom .PS1 file. No attempt is made to fix identified issues.</maml:para>
             <maml:para>-Mode 4 Finds any malconfigurations and creates code snippets to fix each issue. Attempts to fix all identified issues. This mode may require high-privileged access.</maml:para>
@@ -78,7 +78,7 @@
         <maml:description>
           <maml:para>Specifies sets of common script execution modes.</maml:para>
           <maml:para>-Mode 0 Finds any malconfigurations and displays them in the console. No attempt is made to fix identified issues.</maml:para>
-          <maml:para>-Mode 1 Finds any malconfigurations and displays them in the console. Displays example Powershell snippet that can be used to resolve the issue. No attempt is made to fix identified issues.</maml:para>
+          <maml:para>-Mode 1 Finds any malconfigurations and displays them in the console. Displays example PowerShell snippet that can be used to resolve the issue. No attempt is made to fix identified issues.</maml:para>
           <maml:para>-Mode 2 Finds any malconfigurations and writes them to a series of CSV files. No attempt is made to fix identified issues.</maml:para>
           <maml:para>-Mode 3 Finds any malconfigurations and writes them to a series of CSV files. Creates code snippets to fix each issue and writes them to an environment-specific custom .PS1 file. No attempt is made to fix identified issues.</maml:para>
           <maml:para>-Mode 4 Finds any malconfigurations and creates code snippets to fix each issue. Attempts to fix all identified issues. This mode may require high-privileged access.</maml:para>


### PR DESCRIPTION
## Summary

Fixes confirmed spelling, grammar, and user-facing message issues identified in the repository audit.

## Changes

### Typo / capitalization fixes
- `Powershell` -> `PowerShell` throughout source, docs, XML help, `.editorconfig`, and generated monolithic script
- `CCOMMAND(S)` -> `COMMAND(S)` in `Private/Invoke-Remediation.ps1` (and generated script)
- `direclty` -> `directly` in `Private/Write-HostColorized.ps1` (and generated script)
- `an high-level` -> `a high-level` in `Public/Invoke-Locksmith.ps1` (and generated script)
- `to the purposes` -> `for the purposes` in `Tests/Invoke-TSS.ps1`
- `chose` -> `choose` in `README.md` and `Docs/index.md`

### User-facing message improvements
- Replaced vague `Ope! Something broke.` with an actionable error message in both CSV export catch blocks (Modes 2 and 3) that includes the file path and the actual exception message.

## Scope
- No behavior changes - all edits are in comments, string literals, and documentation.
- No new tests added.
- No general Write-Host remediation.
- Generated root Invoke-Locksmith.ps1 updated to maintain parity with source per repository convention.

## Validation
- PSScriptAnalyzer run on all changed .ps1 files - no new errors or warnings introduced.
