### PR TITLE
Cache risk-rating SID lookups

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -3484,6 +3484,58 @@ function Set-AdditionalTemplateProperty {
     }
 }
 
+function Get-SidObjectClass {
+    <#
+        .SYNOPSIS
+        Returns the AD objectClass for a given SID, using a session-scoped cache to avoid repeated LDAP queries.
+
+        .DESCRIPTION
+        Wraps Get-ADObject with a script-scoped hashtable cache so that repeated SID-to-objectClass lookups
+        within a single Locksmith scan run hit Active Directory only once per unique SID. Common principals
+        such as Domain Users, Authenticated Users, and Domain Computers appear across many issues and
+        benefit most from this cache.
+
+        .PARAMETER Sid
+        The SID string to look up.
+
+        .OUTPUTS
+        PSCustomObject with an objectClass property, or $null if the SID is not found in AD.
+
+        .NOTES
+        The cache ($script:SidObjectClassCache) persists for the lifetime of the module session. It is
+        intentionally not cleared between issues so that common principals are resolved only once per
+        scan run.
+
+        .EXAMPLE
+        $objectClassInfo = Get-SidObjectClass -Sid 'S-1-5-21-...-512'
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Sid
+    )
+
+    if ($null -eq $script:SidObjectClassCache) {
+        $script:SidObjectClassCache = @{}
+    }
+
+    if (-not $script:SidObjectClassCache.ContainsKey($Sid)) {
+        try {
+            # Use -ErrorAction Stop so transient ADWS/AD errors throw rather than producing
+            # $null output. Only cache a result (including $null for a genuine "not found")
+            # on success; leave the key absent on error so the next call can retry.
+            $result = Get-ADObject -Filter { objectSid -eq $Sid } -ErrorAction Stop |
+                Select-Object objectClass
+            $script:SidObjectClassCache[$Sid] = $result
+        } catch {
+            Write-Warning "Get-SidObjectClass: AD lookup failed for SID '$Sid': $_"
+        }
+    }
+
+    return $script:SidObjectClassCache[$Sid]
+}
+
 function Set-RiskRating {
     <#
         .SYNOPSIS
@@ -3553,7 +3605,7 @@ function Set-RiskRating {
         if ($Issue.Technique -eq 'ESC7') {
             # If an Issue can be tied to a principal, the principal's objectClass impacts the Issue's risk
             $SID = $Issue.IdentityReferenceSID.ToString()
-            $IdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $SID } | Select-Object objectClass
+            $IdentityReferenceObjectClass = Get-SidObjectClass -Sid $SID
 
             if ($Issue.IdentityReferenceSID -match $UnsafeUsers) {
                 # Authenticated Users, Domain Users, Domain Computers etc. are very risky
@@ -3615,7 +3667,7 @@ function Set-RiskRating {
 
         # If an Issue can be tied to a principal, the principal's objectClass impacts the Issue's risk
         $SID = $Issue.IdentityReferenceSID.ToString()
-        $IdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $SID } | Select-Object objectClass
+        $IdentityReferenceObjectClass = Get-SidObjectClass -Sid $SID
 
 
         if ($Issue.IdentityReferenceSID -match $UnsafeUsers) {
@@ -3674,7 +3726,7 @@ function Set-RiskRating {
                             }
                         }
                         $escSID = $esc.IdentityReferenceSID.ToString()
-                        $escIdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $escSID } | Select-Object objectClass
+                        $escIdentityReferenceObjectClass = Get-SidObjectClass -Sid $escSID
                         if ($escSID -match $SafeUsers) {
                             # Safe Users are admins. Authenticating as an admin is bad.
                             $Principals += $esc.IdentityReference.Value
@@ -3725,7 +3777,7 @@ function Set-RiskRating {
                             }
                         }
                         $escSID = $esc.IdentityReferenceSID.ToString()
-                        $escIdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $escSID } | Select-Object objectClass
+                        $escIdentityReferenceObjectClass = Get-SidObjectClass -Sid $escSID
                         if ($escSID -match $SafeUsers) {
                             # Safe Users are admins. Authenticating as an admin is bad.
                             $Principals += $esc.IdentityReference.Value
@@ -3780,7 +3832,7 @@ function Set-RiskRating {
                             }
                         }
                         $escSID = $esc.IdentityReferenceSID.ToString()
-                        $escIdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $escSID } | Select-Object objectClass
+                        $escIdentityReferenceObjectClass = Get-SidObjectClass -Sid $escSID
                         if ($escSID -match $UnsafeUsers) {
                             # Unsafe Users are large groups.
                             $Principals += $esc.IdentityReference.Value
@@ -3818,7 +3870,7 @@ function Set-RiskRating {
                             }
                         }
                         $escSID = $esc.IdentityReferenceSID.ToString()
-                        $escIdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $escSID } | Select-Object objectClass
+                        $escIdentityReferenceObjectClass = Get-SidObjectClass -Sid $escSID
                         if ($escSID -match $UnsafeUsers) {
                             # Unsafe Users are large groups.
                             $Principals += $esc.IdentityReference.Value
@@ -3860,7 +3912,7 @@ function Set-RiskRating {
                             }
                         }
                         $OtherIssueSID = $OtherIssue.IdentityReferenceSID.ToString()
-                        $OtherIssueIdentityReferenceObjectClass = (Get-ADObject -Filter { objectSid -eq $OtherIssueSID } | Select-Object objectClass).objectClass
+                        $OtherIssueIdentityReferenceObjectClass = (Get-SidObjectClass -Sid $OtherIssueSID).objectClass
                         if ($OtherIssueSID -match $UnsafeUsers) {
                             # Unsafe Users are large groups.
                             $Principals += $OtherIssue.IdentityReference.Value

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -3529,7 +3529,10 @@ function Get-SidObjectClass {
                 Select-Object objectClass
             $script:SidObjectClassCache[$Sid] = $result
         } catch {
-            Write-Warning "Get-SidObjectClass: AD lookup failed for SID '$Sid': $_"
+            # Re-emit to the error stream so callers can detect/handle failures and so
+            # $ErrorActionPreference is honoured. The key is intentionally left absent
+            # so a subsequent call can retry the AD query.
+            Write-Error -ErrorRecord $_
         }
     }
 

--- a/Private/Set-RiskRating.ps1
+++ b/Private/Set-RiskRating.ps1
@@ -1,3 +1,47 @@
+function Get-SidObjectClass {
+    <#
+        .SYNOPSIS
+        Returns the AD objectClass for a given SID, using a session-scoped cache to avoid repeated LDAP queries.
+
+        .DESCRIPTION
+        Wraps Get-ADObject with a script-scoped hashtable cache so that repeated SID-to-objectClass lookups
+        within a single Locksmith scan run hit Active Directory only once per unique SID. Common principals
+        such as Domain Users, Authenticated Users, and Domain Computers appear across many issues and
+        benefit most from this cache.
+
+        .PARAMETER Sid
+        The SID string to look up.
+
+        .OUTPUTS
+        PSCustomObject with an objectClass property, or $null if the SID is not found in AD.
+
+        .NOTES
+        The cache ($script:SidObjectClassCache) persists for the lifetime of the module session. It is
+        intentionally not cleared between issues so that common principals are resolved only once per
+        scan run.
+
+        .EXAMPLE
+        $objectClassInfo = Get-SidObjectClass -Sid 'S-1-5-21-...-512'
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Sid
+    )
+
+    if ($null -eq $script:SidObjectClassCache) {
+        $script:SidObjectClassCache = @{}
+    }
+
+    if (-not $script:SidObjectClassCache.ContainsKey($Sid)) {
+        $script:SidObjectClassCache[$Sid] = Get-ADObject -Filter { objectSid -eq $Sid } |
+            Select-Object objectClass
+    }
+
+    return $script:SidObjectClassCache[$Sid]
+}
+
 function Set-RiskRating {
     <#
         .SYNOPSIS
@@ -67,7 +111,7 @@ function Set-RiskRating {
         if ($Issue.Technique -eq 'ESC7') {
             # If an Issue can be tied to a principal, the principal's objectClass impacts the Issue's risk
             $SID = $Issue.IdentityReferenceSID.ToString()
-            $IdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $SID } | Select-Object objectClass
+            $IdentityReferenceObjectClass = Get-SidObjectClass -Sid $SID
 
             if ($Issue.IdentityReferenceSID -match $UnsafeUsers) {
                 # Authenticated Users, Domain Users, Domain Computers etc. are very risky
@@ -126,7 +170,7 @@ function Set-RiskRating {
 
         # If an Issue can be tied to a principal, the principal's objectClass impacts the Issue's risk
         $SID = $Issue.IdentityReferenceSID.ToString()
-        $IdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $SID } | Select-Object objectClass
+        $IdentityReferenceObjectClass = Get-SidObjectClass -Sid $SID
 
 
         if ($Issue.IdentityReferenceSID -match $UnsafeUsers) {
@@ -180,7 +224,7 @@ function Set-RiskRating {
                             }
                         }
                         $escSID = $esc.IdentityReferenceSID.ToString()
-                        $escIdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $escSID } | Select-Object objectClass
+                        $escIdentityReferenceObjectClass = Get-SidObjectClass -Sid $escSID
                         if ($escSID -match $SafeUsers) {
                             # Safe Users are admins. Authenticating as an admin is bad.
                             $Principals += $esc.IdentityReference.Value
@@ -227,7 +271,7 @@ function Set-RiskRating {
                             }
                         }
                         $escSID = $esc.IdentityReferenceSID.ToString()
-                        $escIdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $escSID } | Select-Object objectClass
+                        $escIdentityReferenceObjectClass = Get-SidObjectClass -Sid $escSID
                         if ($escSID -match $SafeUsers) {
                             # Safe Users are admins. Authenticating as an admin is bad.
                             $Principals += $esc.IdentityReference.Value
@@ -278,7 +322,7 @@ function Set-RiskRating {
                             }
                         }
                         $escSID = $esc.IdentityReferenceSID.ToString()
-                        $escIdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $escSID } | Select-Object objectClass
+                        $escIdentityReferenceObjectClass = Get-SidObjectClass -Sid $escSID
                         if ($escSID -match $UnsafeUsers) {
                             # Unsafe Users are large groups.
                             $Principals += $esc.IdentityReference.Value
@@ -314,7 +358,7 @@ function Set-RiskRating {
                             }
                         }
                         $escSID = $esc.IdentityReferenceSID.ToString()
-                        $escIdentityReferenceObjectClass = Get-ADObject -Filter { objectSid -eq $escSID } | Select-Object objectClass
+                        $escIdentityReferenceObjectClass = Get-SidObjectClass -Sid $escSID
                         if ($escSID -match $UnsafeUsers) {
                             # Unsafe Users are large groups.
                             $Principals += $esc.IdentityReference.Value
@@ -354,7 +398,7 @@ function Set-RiskRating {
                             }
                         }
                         $OtherIssueSID = $OtherIssue.IdentityReferenceSID.ToString()
-                        $OtherIssueIdentityReferenceObjectClass = (Get-ADObject -Filter { objectSid -eq $OtherIssueSID } | Select-Object objectClass).objectClass
+                        $OtherIssueIdentityReferenceObjectClass = (Get-SidObjectClass -Sid $OtherIssueSID).objectClass
                         if ($OtherIssueSID -match $UnsafeUsers) {
                             # Unsafe Users are large groups.
                             $Principals += $OtherIssue.IdentityReference.Value

--- a/Private/Set-RiskRating.ps1
+++ b/Private/Set-RiskRating.ps1
@@ -35,8 +35,16 @@ function Get-SidObjectClass {
     }
 
     if (-not $script:SidObjectClassCache.ContainsKey($Sid)) {
-        $script:SidObjectClassCache[$Sid] = Get-ADObject -Filter { objectSid -eq $Sid } |
-            Select-Object objectClass
+        try {
+            # Use -ErrorAction Stop so transient ADWS/AD errors throw rather than producing
+            # $null output. Only cache a result (including $null for a genuine "not found")
+            # on success; leave the key absent on error so the next call can retry.
+            $result = Get-ADObject -Filter { objectSid -eq $Sid } -ErrorAction Stop |
+                Select-Object objectClass
+            $script:SidObjectClassCache[$Sid] = $result
+        } catch {
+            Write-Warning "Get-SidObjectClass: AD lookup failed for SID '$Sid': $_"
+        }
     }
 
     return $script:SidObjectClassCache[$Sid]

--- a/Private/Set-RiskRating.ps1
+++ b/Private/Set-RiskRating.ps1
@@ -43,7 +43,10 @@ function Get-SidObjectClass {
                 Select-Object objectClass
             $script:SidObjectClassCache[$Sid] = $result
         } catch {
-            Write-Warning "Get-SidObjectClass: AD lookup failed for SID '$Sid': $_"
+            # Re-emit to the error stream so callers can detect/handle failures and so
+            # $ErrorActionPreference is honoured. The key is intentionally left absent
+            # so a subsequent call can retry the AD query.
+            Write-Error -ErrorRecord $_
         }
     }
 


### PR DESCRIPTION
## Summary

Eliminates repeated Active Directory LDAP queries for the same SID during a Locksmith scan run.

## Problem

`Set-RiskRating` had seven call sites all performing `Get-ADObject -Filter { objectSid -eq $SID } | Select-Object objectClass`. Common principals appear in many template ACLs and were re-queried on every issue.

## Solution

New `Get-SidObjectClass` helper with `$script:SidObjectClassCache` in `Private/Set-RiskRating.ps1`. Transient ADWS errors are not cached (key stays absent for retry); errors re-emitted via `Write-Error -ErrorRecord $_` so callers can detect failures and `$ErrorActionPreference` is honoured. All 7 call sites replaced.

## Scope

- Caches repeated SID lookups in `Set-RiskRating.ps1`
- Preserves all risk score semantics
- `Invoke-Locksmith.ps1` manually updated for parity (`Build/Build-Module.ps1` is NOT run in CI)
- No Pester tests, no remediation/TLS changes, no broad refactoring

## Static analysis

PSScriptAnalyzer: no new warnings introduced.