### PR TITLE
fix: preserve non-ASCII characters in CSV output

### DIFF
--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -5381,7 +5381,7 @@ Invoke-Locksmith -Mode 1
             $Output = Join-Path -Path $OutputPath -ChildPath "$FilePrefix ADCSIssues.CSV"
             Write-Host "Writing AD CS issues to $Output..."
             try {
-                $AllIssues | Select-Object Forest, Technique, Name, Issue, @{l = 'Risk'; e = { $_.RiskName } } | Export-Csv -NoTypeInformation -Encoding UTF8 $Output 
+                $AllIssues | Select-Object Forest, Technique, Name, Issue, @{l = 'Risk'; e = { $_.RiskName } } | Export-Csv -NoTypeInformation -Encoding UTF8 $Output
                 Write-Host "$Output created successfully!`n"
             }
             catch {

--- a/Invoke-Locksmith.ps1
+++ b/Invoke-Locksmith.ps1
@@ -5381,7 +5381,7 @@ Invoke-Locksmith -Mode 1
             $Output = Join-Path -Path $OutputPath -ChildPath "$FilePrefix ADCSIssues.CSV"
             Write-Host "Writing AD CS issues to $Output..."
             try {
-                $AllIssues | Select-Object Forest, Technique, Name, Issue, @{l = 'Risk'; e = { $_.RiskName } } | Export-Csv -NoTypeInformation $Output
+                $AllIssues | Select-Object Forest, Technique, Name, Issue, @{l = 'Risk'; e = { $_.RiskName } } | Export-Csv -NoTypeInformation -Encoding UTF8 $Output 
                 Write-Host "$Output created successfully!`n"
             }
             catch {

--- a/Public/Invoke-Locksmith.ps1
+++ b/Public/Invoke-Locksmith.ps1
@@ -363,7 +363,7 @@ Invoke-Locksmith -Mode 1
             $Output = Join-Path -Path $OutputPath -ChildPath "$FilePrefix ADCSIssues.CSV"
             Write-Host "Writing AD CS issues to $Output..."
             try {
-                $AllIssues | Select-Object Forest, Technique, Name, Issue, @{l = 'Risk'; e = { $_.RiskName } } | Export-Csv -NoTypeInformation $Output
+                $AllIssues | Select-Object Forest, Technique, Name, Issue, @{l = 'Risk'; e = { $_.RiskName } } | Export-Csv -NoTypeInformation -Encoding UTF8 $Output
                 Write-Host "$Output created successfully!`n"
             } catch {
                 Write-Host 'Ope! Something broke.'
@@ -373,7 +373,7 @@ Invoke-Locksmith -Mode 1
             $Output = Join-Path -Path $OutputPath -ChildPath "$FilePrefix ADCSRemediation.CSV"
             Write-Host "Writing AD CS issues to $Output..."
             try {
-                $AllIssues | Select-Object Forest, Technique, Name, DistinguishedName, Issue, Fix, @{l = 'Risk'; e = { $_.RiskName } }, @{l = 'Risk Score'; e = { $_.RiskValue } }, @{l = 'Risk Score Detail'; e = { $_.RiskScoring -join "`n" } } | Export-Csv -NoTypeInformation $Output
+                $AllIssues | Select-Object Forest, Technique, Name, DistinguishedName, Issue, Fix, @{l = 'Risk'; e = { $_.RiskName } }, @{l = 'Risk Score'; e = { $_.RiskValue } }, @{l = 'Risk Score Detail'; e = { $_.RiskScoring -join "`n" } } | Export-Csv -NoTypeInformation -Encoding UTF8 $Output
                 Write-Host "$Output created successfully!`n"
             } catch {
                 Write-Host 'Ope! Something broke.'


### PR DESCRIPTION
## Summary
When a certificate template name contains non-ASCII characters (e.g. Japanese), `Invoke-Locksmith` writes them as `?` in its CSV output. The affected files are `*ADCSIssues.CSV` (Mode 2) and `*ADCSRemediation.CSV` (Mode 3).

Example (Mode 2), template name `脆弱テンプレートESC1`:

```
Before: "yamato.local","ESC1","????????ESC1", ...
After:  "yamato.local","ESC1","脆弱テンプレートESC1", ...
```

## Root cause
The two `Export-Csv` calls don't specify `-Encoding`, so they fall back to the cmdlet's default — and that default differs by PowerShell version.

References:
- Windows PowerShell 5.1 — Default value: `ASCII`
  https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-5.1
- PowerShell 7.6 — Default value: `UTF8NoBOM`
  https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/export-csv?view=powershell-7.6

## Fix
Add `-Encoding UTF8` to the two `Export-Csv` calls in `Public/Invoke-Locksmith.ps1`. `UTF8` is a valid value on both Windows PowerShell 5.1 and PowerShell 7+.

## Testing
Ran `Invoke-Locksmith -Mode 2 -OutputPath .` on Windows PowerShell 5.1 against a forest containing a template whose name includes Japanese characters. Before the change the name was written as `?`; after the change the CSV preserves the characters correctly.
