### PR TITLE
Fix: detect CA availability via RPC (TCP 135) instead of ICMP ping

### DIFF
--- a/Private/Set-AdditionalCAProperty.ps1
+++ b/Private/Set-AdditionalCAProperty.ps1
@@ -129,7 +129,7 @@
                 $CAHostDistinguishedName = (Get-ADObject -Filter { (Name -eq $CAHostName) -and (objectclass -eq 'computer') } -Server $ForestGC ).DistinguishedName
                 $CAHostFQDN = (Get-ADObject -Filter { (Name -eq $CAHostName) -and (objectclass -eq 'computer') } -Properties DnsHostname -Server $ForestGC).DnsHostname
             }
-            $ping = if ($CAHostFQDN) { Test-Connection -ComputerName $CAHostFQDN -Count 1 -Quiet } else { Write-Warning "Unable to resolve $($_.Name) Fully Qualified Domain Name (FQDN)" }
+            $ping = if ($CAHostFQDN) { Test-NetConnection -ComputerName $CAHostFQDN -Port 135 -InformationLevel Quiet -WarningAction SilentlyContinue } else { Write-Warning "Unable to resolve $($_.Name) Fully Qualified Domain Name (FQDN)" }
             if ($ping) {
                 try {
                     if ($Credential) {


### PR DESCRIPTION
**Problem**
`Set-AdditionalCAProperty` gates all live-CA reads (`certutil -getreg`) behind
an ICMP echo test:

    Test-Connection -ComputerName $CAHostFQDN -Count 1 -Quiet

Windows Firewall does not allow inbound ICMPv4 Echo by default (the
"File and Printer Sharing (Echo Request - ICMPv4-In)" rule is disabled out of
the box). On such hosts the CA is fully reachable over RPC/DCOM, yet this ping
fails, so the CA is reported as "CA Unavailable". This yields false positives
and runtime errors: `.Translate()` throws IdentityNotMappedException on the
"CA Unavailable" placeholder, and `$Issue.IdentityReferenceSID.ToString()` is
then called on the resulting null SID (InvokeMethodOnNull).

**Fix**
Test TCP reachability on 135 (RPC Endpoint Mapper), matching the actual
transport. Unreachable-CA cases remain handled by the existing per-`certutil`
try/catch.

    Test-NetConnection -ComputerName $CAHostFQDN -Port 135 -InformationLevel Quiet -WarningAction SilentlyContinue

**Compatibility**
Test-NetConnection is part of the inbox NetTCPIP module, documented for
Windows Server 2016 and later (with `-Port` and `-InformationLevel Quiet`):
https://learn.microsoft.com/powershell/module/nettcpip/test-netconnection?view=windowsserver2016-ps

**Testing**
In an environment where inbound ICMP echo is blocked (the Windows Firewall
default) but the CA is reachable over RPC, the current code logs runtime errors
during the CA scan and reports the DETECT/ESC6/ESC7/ESC11/ESC16 checks as
"CA Unavailable". With this change the scan completes cleanly with no errors,
and those checks are evaluated against the real CA configuration — identical to
a run where ICMP is allowed, but without changing the firewall.

**Scope notes**
- The same ICMP pattern also exists in `Tests/Invoke-TSS.ps1` (line 408), but I
  wasn't sure whether it should be fixed too, so I've left it unchanged.

**References**
- AD CS uses RPC/DCOM (RPC endpoint mapper TCP 135, SMB TCP 445 and 139, and dynamic ports 49152-65535):
  https://learn.microsoft.com/troubleshoot/windows-server/networking/service-overview-and-network-port-requirements#certificate-services
- AD CS firewall rules — DCOM/RPC, HTTPS, Kerberos, LDAP:
  https://learn.microsoft.com/archive/blogs/pki/firewall-rules-for-active-directory-certificate-services
